### PR TITLE
fix(glossary-view): add correct url for glossary.json

### DIFF
--- a/libs/glossary-view/index.js
+++ b/libs/glossary-view/index.js
@@ -8,8 +8,7 @@ const Glossary = (props) => {
 
   useEffect(() => {
     if (typeof window !== undefined) {
-      const url = document.location.pathname.replace(/\/$/, '');
-      const JSONurl = `${url}.json`;
+      const JSONurl = withBaseUrl('docs/glossary.json');
       if (!content) {
         if (!window._cachedGlossary) {
           fetch(JSONurl)


### PR DESCRIPTION
The glossary file may be located anywhere inside the `docs` folder, not specifically in the root dir. The `glossary.json` file though will always be resolved in the `/baseUrl/docs/glossary.json` path, because it is stored and cached in the `.docusaurus` directory.