### PR TITLE
chore(plugins): make glossary and term preview customizable

### DIFF
--- a/plugins/webpack-glossary-loader/index.js
+++ b/plugins/webpack-glossary-loader/index.js
@@ -1,14 +1,14 @@
 const parseMD = require('parse-md').default;
 const store = require('@grnet/terminology-store');
 const path = require('path');
-const importStatement = `
-
-import Glossary from "@grnet/docusaurus-glossary-view";
-
-`;
 
 module.exports = function(source) {
   const urls = store.terms;
+  const importStatement = `
+
+  import Glossary from "${ this.query.glossaryComponentPath || "@grnet/docusaurus-glossary-view"}";
+
+  `;
   this.cacheable(false)
   this.addDependency(path.posix.join(this.query.docsDir, 'glossary.json'))
   this.emitFile(

--- a/plugins/webpack-terms-replace-loader/index.js
+++ b/plugins/webpack-terms-replace-loader/index.js
@@ -2,12 +2,6 @@ const parseMD = require('parse-md').default;
 const store = require('@grnet/terminology-store');
 const path = require('path');
 const pkgUp = require('pkg-up');
-const importStatement = `
-
-import Term from "@grnet/docusaurus-term-preview";
-
-`;
-
 const pkg = pkgUp.sync({ cwd: process.cwd() });
 const root = process.platform === 'win32' ? path.win32.dirname(pkg) : path.dirname(pkg);
 
@@ -15,6 +9,11 @@ module.exports = function(source) {
   const urlsRegex = /\[.*?\]\(.*?\)/gim;
   const urlRegex = /\[(.*?)\]\((.*?)\)/;
   const urls = source.match(urlsRegex) || [];
+  const importStatement = `
+
+  import Term from "${ this.query.termPreviewComponentPath || "@grnet/docusaurus-term-preview"}";
+
+  `;
   if (urls.length > 0) {
     const { content } = parseMD(source);
     source = source.replace(content, importStatement + content);


### PR DESCRIPTION
Users will have the ability to use their own custom components for the glossary file and term preview tooltip, instead of using the ones provided by `@grnet/docusaurus-term-preview` and `@grnet/docusaurus-glossary-view`.

To modify the default options, users can edit the plugins section in `docusaurus.config.js` as shown below:

```
plugins: [
    ['@grnet/docusaurus-terminology', {
      termsDir: './docs/terms',
      docsDir: './docs/',
      glossaryFilepath: './docs/glossary.md',
      glossaryComponentPath: 'path/to/your/component',
      termPreviewPath: 'path/to/your/component',
    }],
  ],
```

If the user doesn't provide the `glossaryComponentPath` and `termPreviewPath`, or prefers to use the defaults, the options will be as follows:

```
plugins: [
    ['@grnet/docusaurus-terminology', {
      ...
      glossaryComponentPath: '@grnet/docusaurus-glossary-view',
      termPreviewPath: '@grnet/docusaurus-term-preview',
    }],
  ],
```