### PR TITLE
Fix and improve urlsRegex to match only with md url

### DIFF
--- a/plugins/webpack-terms-replace-loader/index.js
+++ b/plugins/webpack-terms-replace-loader/index.js
@@ -6,7 +6,7 @@ const pkg = pkgUp.sync({ cwd: process.cwd() });
 const root = process.platform === 'win32' ? path.win32.dirname(pkg) : path.dirname(pkg);
 
 module.exports = function(source) {
-  const urlsRegex = /\[.*?\]\(.*?\)/gim;
+  const urlsRegex = /(?<!!)\[[^\]]+\]\([^)]+\)/g;
   const urlRegex = /\[(.*?)\]\((.*?)\)/;
   const urls = source.match(urlsRegex) || [];
   const importStatement = `


### PR DESCRIPTION
Fixes for:
* Issue #16 - Failed to parse: `- [ ] Text [This is the example-term](./terms/example-term)`
* Issue #17 - Failed to parse: `![image info](./terms/image.png)`