### PR TITLE
(fix) Changed condition for docusaurus terminology loaders registration

### DIFF
--- a/plugins/docusaurus-terminology/index.js
+++ b/plugins/docusaurus-terminology/index.js
@@ -43,8 +43,11 @@ module.exports = function (context, options) {
         }
       }
       options.resolved = true;
+      const testMdFilename = 'test.md';
+      const testMdxFilename = 'test.mdx';
       const newRules = config.module.rules.map(rule => {
-        if (rule.use && rule.use.some(({ loader }) => loader && loader.includes("plugin-content-docs"))) {
+        const ruleRegExp = new RegExp(rule.test);
+        if (ruleRegExp.test(testMdFilename) && ruleRegExp.test(testMdxFilename)) {
           rule.oneOf = [
             {
               test: glossaryRegex,


### PR DESCRIPTION
This plugin doesn't work with newest docusaurus version since 3.4.0 because of incorrect loaders registration. Docusaurus doesn't work with docusaurus/plugin-content-doc

Pull request fix it