### PR TITLE
fix: add support for react 19

### DIFF
--- a/examples/terminology-example-baseurl/package.json
+++ b/examples/terminology-example-baseurl/package.json
@@ -20,8 +20,8 @@
     "@mdx-js/react": "^3.0.0",
     "clsx": "^1.2.1",
     "prism-react-renderer": "^2.1.0",
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
     "@grnet/docusaurus-term-preview": "2.0.0-rc.2",
     "@grnet/docusaurus-glossary-view": "2.0.0-rc.2"
   },

--- a/examples/terminology-example/package.json
+++ b/examples/terminology-example/package.json
@@ -20,8 +20,8 @@
     "@mdx-js/react": "^3.0.0",
     "clsx": "^1.2.1",
     "prism-react-renderer": "^2.1.0",
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
     "@grnet/docusaurus-term-preview": "2.0.0-rc.2",
     "@grnet/docusaurus-glossary-view": "2.0.0-rc.2"
   },

--- a/libs/glossary-view/package.json
+++ b/libs/glossary-view/package.json
@@ -13,8 +13,8 @@
   },
   "peerDependencies": {
     "@docusaurus/core": "^3.0.1",
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0"
   },
   "devDependencies": {
     "@babel/core": "7.12.13",

--- a/libs/glossary-view/package.json
+++ b/libs/glossary-view/package.json
@@ -5,6 +5,7 @@
   "main": "dist/index.js",
   "author": "GRNET Developers <devs@lists.grnet.gr>",
   "license": "BSD-2-Clause",
+  "type": "module",
   "publishConfig": {
     "access": "public"
   },
@@ -17,13 +18,13 @@
     "react-dom": "^18.0.0 || ^19.0.0"
   },
   "devDependencies": {
-    "@babel/core": "7.12.13",
-    "@babel/preset-env": "7.12.13",
-    "@babel/preset-react": "7.12.13",
-    "@rollup/plugin-babel": "5.2.3",
-    "@rollup/plugin-commonjs": "17.1.0",
-    "@rollup/plugin-node-resolve": "11.1.1",
-    "@rollup/plugin-replace": "2.3.4",
-    "rollup": "2.38.5"
+    "@babel/core": "7.28.4",
+    "@babel/preset-env": "7.28.3",
+    "@babel/preset-react": "7.27.1",
+    "@rollup/plugin-babel": "6.0.4",
+    "@rollup/plugin-commonjs": "28.0.6",
+    "@rollup/plugin-node-resolve": "16.0.2",
+    "@rollup/plugin-replace": "6.0.2",
+    "rollup": "4.52.4"
   }
 }

--- a/libs/term-preview/index.js
+++ b/libs/term-preview/index.js
@@ -1,7 +1,7 @@
-import React, { useEffect, useState } from "react";
 import BrowserOnly from "@docusaurus/BrowserOnly";
-import RcTooltip from "rc-tooltip";
-import "rc-tooltip/assets/bootstrap_white.css";
+import RcTooltip from "@rc-component/tooltip";
+import "@rc-component/tooltip/assets/bootstrap_white.css";
+import React, { useEffect, useState } from "react";
 import "./tooltip-styles.css";
 
 const link = {
@@ -35,7 +35,9 @@ const Content = React.forwardRef(({ setContent, content, url, theme }, ref) => {
       {content ? (
         <>
           <h4>{content.metadata.title}</h4>
-          <div dangerouslySetInnerHTML={{ __html: content.metadata.hoverText }}></div>
+          <div
+            dangerouslySetInnerHTML={{ __html: content.metadata.hoverText }}
+          ></div>
         </>
       ) : (
         "loading..."

--- a/libs/term-preview/package.json
+++ b/libs/term-preview/package.json
@@ -5,12 +5,13 @@
   "main": "dist/index.js",
   "author": "GRNET Developers <devs@lists.grnet.gr>",
   "license": "BSD-2-Clause",
+  "type": "module",
   "publishConfig": {
     "access": "public"
   },
   "dependencies": {
-    "rc-tooltip": "5.0.2",
-    "rollup": "2.38.5"
+    "rc-tooltip": "^6.0.0",
+    "rollup": "^4.0.0"
   },
   "scripts": {
     "build": "rollup -c --silent"
@@ -21,15 +22,15 @@
     "react-dom": "^18.0.0 || ^19.0.0"
   },
   "devDependencies": {
-    "@babel/core": "7.12.13",
-    "@babel/preset-env": "7.12.13",
-    "@babel/preset-react": "7.12.13",
-    "@rollup/plugin-babel": "5.2.3",
-    "@rollup/plugin-commonjs": "17.1.0",
-    "@rollup/plugin-node-resolve": "11.1.1",
-    "@rollup/plugin-replace": "2.3.4",
-    "postcss": "8.4.4",
-    "rollup-plugin-import-css": "2.0.0",
-    "rollup-plugin-postcss": "4.0.0"
+    "@babel/core": "7.28.4",
+    "@babel/preset-env": "7.28.3",
+    "@babel/preset-react": "7.27.1",
+    "@rollup/plugin-babel": "6.0.4",
+    "@rollup/plugin-commonjs": "28.0.6",
+    "@rollup/plugin-node-resolve": "16.0.2",
+    "@rollup/plugin-replace": "6.0.2",
+    "postcss": "8.5.6",
+    "rollup-plugin-import-css": "4.0.2",
+    "rollup-plugin-postcss": "4.0.2"
   }
 }

--- a/libs/term-preview/package.json
+++ b/libs/term-preview/package.json
@@ -10,7 +10,7 @@
     "access": "public"
   },
   "dependencies": {
-    "rc-tooltip": "^6.0.0"
+    "@rc-component/tooltip": "^1.0.0"
   },
   "scripts": {
     "build": "rollup -c --silent"

--- a/libs/term-preview/package.json
+++ b/libs/term-preview/package.json
@@ -9,7 +9,6 @@
     "access": "public"
   },
   "dependencies": {
-    "postel": "0.1.5",
     "rc-tooltip": "5.0.2",
     "rollup": "2.38.5"
   },

--- a/libs/term-preview/package.json
+++ b/libs/term-preview/package.json
@@ -10,8 +10,7 @@
     "access": "public"
   },
   "dependencies": {
-    "rc-tooltip": "^6.0.0",
-    "rollup": "^4.0.0"
+    "rc-tooltip": "^6.0.0"
   },
   "scripts": {
     "build": "rollup -c --silent"
@@ -31,6 +30,7 @@
     "@rollup/plugin-replace": "6.0.2",
     "postcss": "8.5.6",
     "rollup-plugin-import-css": "4.0.2",
-    "rollup-plugin-postcss": "4.0.2"
+    "rollup-plugin-postcss": "4.0.2",
+    "rollup": "4.52.4"
   }
 }

--- a/libs/term-preview/package.json
+++ b/libs/term-preview/package.json
@@ -17,8 +17,8 @@
   },
   "peerDependencies": {
     "@docusaurus/core": "^3.0.1",
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0"
   },
   "devDependencies": {
     "@babel/core": "7.12.13",


### PR DESCRIPTION
This PR widens the peerDependencies to include react 19. Additionally (can be put into another PR), it updates all dependencies to the newest major versions and it updates all devDependencies to the latest version.